### PR TITLE
Endpoint Documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,134 @@
-# README
+# Project: Koroibos
+Welcome to Koroibos, a JSON API designed to expose endpoints to display data and statistics from the 2016 Summer Olympic Games.
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Intent
+This project was completed in 7 days as a requirement for Module 4 at Turing School of Software & Design.
 
-Things you may want to cover:
+The project was built using Ruby on Rails which implements the following:
 
-* Ruby version
+* Object oriented programming principles
+* Test Driven Development - TDD.
+* Advanced database queries and calculations using ActiveRecord.
 
-* System dependencies
+Production URL: http://koroibos.us-east-2.elasticbeanstalk.com
+GitHub Projects Board: https://github.com/jalena-penaligon/koroibos/projects/1
 
-* Configuration
+## Tech Stack
+* Rails 5.2.3
+* Ruby 2.6.3
+* PostgreSQL
 
-* Database creation
+## Instructions
+  ### How to setup:
+      git@github.com:jalena-penaligon/koroibos.git
+      cd koroibos
+      bundle
+      rake db:{create,migrate,seed}
+      rails s
 
-* Database initialization
+  ### Available Endpoints:
+   #### GET /api/v1/olympians
+      Sample Response:
+      {
+        olympians: [
+        {
+          name: "Andreea Aanei",
+          team: "Romania",
+          age: 22,
+          sport: "Weightlifting",
+          total_medals_won: 0
+        },
+        {
+          name: "Nstor Abad Sanjun",
+          team: "Spain",
+          age: 23,
+          sport: "Gymnastics",
+          total_medals_won: 0
+      }]
+    }
 
-* How to run the test suite
+   #### GET /api/v1/olympians?age=youngest
+       Sample Response:
+       {
+        olympian: [
+          {
+            name: "Ana Iulia Dascl",
+            team: "Romania",
+            age: 13,
+            sport: "Swimming",
+            total_medals_won: 0
+          }]
+        }
 
-* Services (job queues, cache servers, search engines, etc.)
+  #### GET /api/v1/olympians?age=oldest
+      Sample Response:
+      {
+       olympian: [
+         {
+           name: "Julie Brougham",
+          team: "New Zealand",
+          age: 62,
+          sport: "Equestrianism",
+          total_medals_won: 0
+         }]
+       }
+  #### GET /api/v1/olympian_stats
+      Sample Response:
+      {
+        olympian_stats: {
+          total_competing_olympians: 2850,
+          average_weight: {
+            unit: "kg",
+            male_olympians: 77.87,
+            female_olympians: 61.41
+          },
+          average_age: 26.37
+        }
+      }
 
-* Deployment instructions
+  #### GET /api/v1/events
+      Sample Response:
+      {
+        events: [{
+          sport: "Weightlifting",
+          events: [
+            "Weightlifting Men's Light-Heavyweight",
+            "Weightlifting Women's Heavyweight",
+            "Weightlifting Men's Bantamweight",
+            "Weightlifting Women's Featherweight",
+            "Weightlifting Women's Light-Heavyweight",
+            "Weightlifting Women's Super-Heavyweight",
+            "Weightlifting Men's Heavyweight",
+            "Weightlifting Men's Middleweight",
+            "Weightlifting Men's Middle-Heavyweight",
+            "Weightlifting Men's Featherweight",
+            "Weightlifting Women's Flyweight",
+            "Weightlifting Women's Middleweight",
+            "Weightlifting Women's Lightweight",
+            "Weightlifting Men's Lightweight",
+            "Weightlifting Men's Super-Heavyweight"
+          ]
+        }]
+      }
 
-* ...
+  #### GET /api/v1/events/:id/medalists
+      Sample Response:
+        {
+          event: "Diving Women's Springboard",
+          medalists: [{
+            name: "Tania Cagnotto (-Parolin)",
+            team: "Italy",
+            age: 31,
+            medal: "Bronze"
+          }]
+        }
+
+  ### Running Tests:
+    Run tests with rspec:
+        $ rspec
+
+  ## Core Contributors:
+  Jalena Taylor: https://github.com/jalena-penaligon/
+
+  ## How to Contribute:
+  - Fork & clone this repository. Make the desired changes and open a pull request, tagging @jalena-penaligon

--- a/app/models/sport.rb
+++ b/app/models/sport.rb
@@ -5,7 +5,7 @@ class Sport < ApplicationRecord
 
   def as_json options={}
     {
-      name: name,
+      sport: name,
       events: self.events.pluck(:name)
     }
   end

--- a/spec/models/sport_spec.rb
+++ b/spec/models/sport_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Sport, type: :model do
       weightlifting_event = weightlifting.events.create(name: "Weightlifting Women's Super-Heavyweight")
 
       expect(weightlifting.as_json).to be_a(Hash)
-      expect(weightlifting.as_json).to have_key(:name)
+      expect(weightlifting.as_json).to have_key(:sport)
       expect(weightlifting.as_json[:events].count).to eq(1)
       expect(weightlifting.as_json[:events]).to be_a(Array)
     end


### PR DESCRIPTION
Documents the following endpoints:
- GET api/v1/olympians
- GET api/v1/olympians?age=youngest
- GET api/v1/olympians?age=oldest
- GET api/v1/olympian_stats
- GET api/v1/events
- GET api/v1/events/:id/medalists

Updates Sport as_json method & sport model test to have a key of "sport" instead of "name" per the project specs.